### PR TITLE
Fix error: "Bad Request: message text is empty"

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -79,6 +79,10 @@ async def handle_message(message: types.Message):
             full_response += chunk
             full_response_stripped = full_response.strip()
 
+            # avoid Bad Request: message text is empty
+            if full_response_stripped == "":
+                continue
+
             if '.' in chunk or '\n' in chunk or '!' in chunk or '?' in chunk:
                 if sent_message:
                     if last_sent_text != full_response_stripped:


### PR DESCRIPTION
Some prompts generate output with no response data in the very beginning. This creates an empty `full_response_stripped` string, which makes aiogram throw `aiogram.exceptions.TelegramBadRequest: Telegram server says - Bad Request: message text is empty`.

An easy fix is to monitor for empty `full_response_stripped` variable with:
```python
            if full_response_stripped == "":
                continue
```