### PR TITLE
Add workflow for docker image build.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,4 +23,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: shrirajhegde/ollama-telegram:latest
+          tags: ruecat/ollama-telegram:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,26 @@
+name: Docker image build
+
+on: [push, release]
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: shrirajhegde/ollama-telegram:latest


### PR DESCRIPTION
- Automate docker image build with GitHub actions.
- Action uses docker buildx to build multiarch images and publishes to dockerhub.

---

Don't forget to set the secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to your repo and correct tag in the file (#L26) before merging.

