### PR TITLE
Add docker image instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ Here's features that you get out of the box:
 ## Installation (Non-Docker)
 + Install latest [Python](https://python.org/downloads)
 + Clone Repository
-```
-git clone https://github.com/ruecat/ollama-telegram
-```
+    ```
+    git clone https://github.com/ruecat/ollama-telegram
+    ```
 + Install requirements from requirements.txt
-```
-pip install -r requirements.txt
-```
+    ```
+    pip install -r requirements.txt
+    ```
 + Enter all values in .env.example
 
 + Rename .env.example -> .env
 
 + Launch bot
 
-```
-python3 run.py
-```
+    ```
+    python3 run.py
+    ```
 ## Installation (Docker Image)
 The official image is available at dockerhub: [ruecat/ollama-telegram](https://hub.docker.com/r/ruecat/ollama-telegram)
 
@@ -98,9 +98,9 @@ The official image is available at dockerhub: [ruecat/ollama-telegram](https://h
 
 ## Installation (Build your own Docker image)
 + Clone Repository
-```
-git clone https://github.com/ruecat/ollama-telegram
-```
+    ```
+    git clone https://github.com/ruecat/ollama-telegram
+    ```
 
 + Enter all values in .env.example
 
@@ -108,14 +108,14 @@ git clone https://github.com/ruecat/ollama-telegram
 
 + Run ONE of the following docker compose commands to start:
     1. To run ollama in docker container (optionally: uncomment GPU part of docker-compose.yml file to enable Nvidia GPU)
-    ```
-    docker compose up --build -d
-    ```
+        ```
+        docker compose up --build -d
+        ```
 
     2. To run ollama from locally installed instance (mainly for **MacOS**, since docker image doesn't support Apple GPU acceleration yet):
-    ```
-    docker compose up --build -d ollama-telegram
-    ```
+        ```
+        docker compose up --build -d ollama-telegram
+        ```
 
 ## Environment Configuration
 |     Parameter     |                                                      Description                                                      | Required? | Default Value |                        Example                        |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,48 @@ pip install -r requirements.txt
 ```
 python3 run.py
 ```
-## Installation (Docker-Compose)
+## Installation (Docker Image)
+The official image is available at dockerhub: [ruecat/ollama-telegram](https://hub.docker.com/r/ruecat/ollama-telegram)
+
++ Download [.env.example](https://github.com/ruecat/ollama-telegram/blob/main/.env.example) file, rename it to .env and populate the variables.
++ Create `docker-compose.yml` (optionally: uncomment GPU part of the file to enable Nvidia GPU)
+```yml
+version: '3.8'
+services:
+  ollama-telegram:
+    image: ruecat/ollama-telegram
+    container_name: ollama-telegram
+    restart: on-failure
+    env_file:
+      - ./.env
+  
+  ollama-server:
+    image: ollama/ollama:latest
+    container_name: ollama-server
+    volumes:
+      - ./ollama:/root/.ollama
+    
+    # Uncomment to enable NVIDIA GPU
+    # Otherwise runs on CPU only:
+
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+    restart: always
+    ports:
+      - '11434:11434'
+```
++ Start the containers
+```sh
+docker compose up -d
+```
+
+## Installation (Build your own Docker image)
 + Clone Repository
 ```
 git clone https://github.com/ruecat/ollama-telegram

--- a/README.md
+++ b/README.md
@@ -56,41 +56,45 @@ The official image is available at dockerhub: [ruecat/ollama-telegram](https://h
 
 + Download [.env.example](https://github.com/ruecat/ollama-telegram/blob/main/.env.example) file, rename it to .env and populate the variables.
 + Create `docker-compose.yml` (optionally: uncomment GPU part of the file to enable Nvidia GPU)
-```yml
-version: '3.8'
-services:
-  ollama-telegram:
-    image: ruecat/ollama-telegram
-    container_name: ollama-telegram
-    restart: on-failure
-    env_file:
-      - ./.env
-  
-  ollama-server:
-    image: ollama/ollama:latest
-    container_name: ollama-server
-    volumes:
-      - ./ollama:/root/.ollama
+
+    ```yml
+    version: '3.8'
+    services:
+      ollama-telegram:
+        image: ruecat/ollama-telegram
+        container_name: ollama-telegram
+        restart: on-failure
+        env_file:
+          - ./.env
+      
+      ollama-server:
+        image: ollama/ollama:latest
+        container_name: ollama-server
+        volumes:
+          - ./ollama:/root/.ollama
+        
+        # Uncomment to enable NVIDIA GPU
+        # Otherwise runs on CPU only:
     
-    # Uncomment to enable NVIDIA GPU
-    # Otherwise runs on CPU only:
+        # deploy:
+        #   resources:
+        #     reservations:
+        #       devices:
+        #         - driver: nvidia
+        #           count: all
+        #           capabilities: [gpu]
+    
+        restart: always
+        ports:
+          - '11434:11434'
+    ```
 
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [gpu]
-
-    restart: always
-    ports:
-      - '11434:11434'
-```
 + Start the containers
-```sh
-docker compose up -d
-```
+
+    ```sh
+    docker compose up -d
+    ```
+
 
 ## Installation (Build your own Docker image)
 + Clone Repository


### PR DESCRIPTION
Added docker image instructions to README.md

---
@ruecat add the following description in dockerhub project overview

---
+ Download [.env.example](https://github.com/ruecat/ollama-telegram/blob/main/.env.example) file, rename it to .env and populate the variables.
+ Create `docker-compose.yml` (optionally: uncomment GPU part of the file to enable Nvidia GPU)

    ```yml
    version: '3.8'
    services:
      ollama-telegram:
        image: ruecat/ollama-telegram
        container_name: ollama-telegram
        restart: on-failure
        env_file:
          - ./.env
      
      ollama-server:
        image: ollama/ollama:latest
        container_name: ollama-server
        volumes:
          - ./ollama:/root/.ollama
        
        # Uncomment to enable NVIDIA GPU
        # Otherwise runs on CPU only:
    
        # deploy:
        #   resources:
        #     reservations:
        #       devices:
        #         - driver: nvidia
        #           count: all
        #           capabilities: [gpu]
    
        restart: always
        ports:
          - '11434:11434'
    ```

+ Start the containers

    ```sh
    docker compose up -d
    ```

