### PR TITLE
fix: set image_base64 to None to create a valid request

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -159,7 +159,7 @@ async def ollama_request(message: types.Message):
     try:
         await bot.send_chat_action(message.chat.id, "typing")
         prompt = message.text or message.caption
-        image_base64 = ''
+        image_base64 = None
         if message.content_type == 'photo':
             image_buffer = io.BytesIO()
             await bot.download(


### PR DESCRIPTION
See #33 - previously, ollama-server apparently could handle a request with images specified in the body as an empty string. Newer versions cannot and return an error like `unsupported image format`.