### PR TITLE
Adding default value for modelicon dictionary in case of KeyError

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -101,7 +101,11 @@ async def modelmanager_callback_handler(query: types.CallbackQuery):
         modelfamilies = ""
         if model["details"]["families"]:
             modelicon = {"llama": "🦙", "clip": "📷"}
-            modelfamilies = "".join([modelicon[family] for family in model['details']['families']])
+            try:
+                modelfamilies = "".join([modelicon[family] for family in model['details']['families']])
+            except KeyError as e:
+                # Use a default value when the key is not found
+                modelfamilies = f"✨"
         # Add a button for each model
         modelmanager_builder.row(
             types.InlineKeyboardButton(


### PR DESCRIPTION
The error is occurring because the modelicon dictionary does not have a key for "gemma" or other newer models. To fix this, you can add a default value to the modelicon dictionary that will be used when a key error occurs.