### PR TITLE
Fixing group messaging

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -203,7 +203,8 @@ async def handle_response(message, response_data, full_response):
     return False
 
 async def send_response(message, text):
-    if message.chat.id == message.from_user.id:
+    # A negative message.chat.id is a group message
+    if message.chat.id < 0 or message.chat.id == message.from_user.id:
         await bot.send_message(chat_id=message.chat.id, text=text)
     else:
         await bot.edit_message_text(


### PR DESCRIPTION

Group messages have a negative message.chat.id
This fixes `send_response()` to be able to handle sending messages back

Before it was trying to edit them and causing server errors:
`aiogram.exceptions.TelegramBadRequest: Telegram server says - Bad Request: message can't be edited
`