### PR TITLE
Fix for error: Bad Request: can't parse entities

### DIFF
--- a/bot/run.py
+++ b/bot/run.py
@@ -3,6 +3,10 @@ from aiogram.enums import ParseMode
 from aiogram.filters.command import Command, CommandStart
 from aiogram.types import Message
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+import telegramify_markdown
+import telegramify_markdown.customize as customize
+customize.strict_markdown = False
+
 from func.interactions import *
 import asyncio
 import traceback
@@ -428,15 +432,22 @@ async def handle_response(message, response_data, full_response):
     return False
 
 async def send_response(message, text):
+    # Escape Markdown special characters to prevent formatting issues
+    text = telegramify_markdown.markdownify(text)
+
     # A negative message.chat.id is a group message
     if message.chat.id < 0 or message.chat.id == message.from_user.id:
-        await bot.send_message(chat_id=message.chat.id, text=text,parse_mode=ParseMode.MARKDOWN)
+        await bot.send_message(
+            chat_id=message.chat.id,
+            text=text,
+            parse_mode="MarkdownV2"
+        )
     else:
         await bot.edit_message_text(
             chat_id=message.chat.id,
             message_id=message.message_id,
             text=text,
-            parse_mode=ParseMode.MARKDOWN,
+            parse_mode="MarkdownV2"
         )
 
 async def ollama_request(message: types.Message, prompt: str = None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dotenv==1.0.0
 aiogram==3.13.1
 ollama
+telegramify-markdown


### PR DESCRIPTION
A simple fix for errors like
aiogram.exceptions.TelegramBadRequest: Telegram server says - Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 2176
and
https://github.com/ruecat/ollama-telegram/issues/79
https://github.com/ruecat/ollama-telegram/issues/76