### PR TITLE
Fix for .env.example: move comments to separate lines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,12 @@ INITMODEL=llama-2
 TIMEOUT=3000
 
 # UNCOMMENT ONE OF THE FOLLOWING LINES:
-# OLLAMA_BASE_URL=localhost # to run ollama without docker, using run.py
-# OLLAMA_BASE_URL=ollama-server # to run ollama in a docker container 
-# OLLAMA_BASE_URL=host.docker.internal # to run ollama locally
+# 1. to run ollama without docker, using run.py:
+# OLLAMA_BASE_URL=localhost
+# 2. OR to run ollama in a docker container:
+# OLLAMA_BASE_URL=ollama-server
+# 3. OR to run ollama locally:
+# OLLAMA_BASE_URL=host.docker.internal
 
 # Log level
 # https://docs.python.org/3/library/logging.html#logging-levels


### PR DESCRIPTION
# Problem Description

I copied `.env.example` and simply uncommented one of the example lines to set the `OLLAMA_BASE_URL`:

https://github.com/ruecat/ollama-telegram/blob/4884bbd1e23902152c3468c9fbc717af56cbd9d2/.env.example#L11

However, I left the explanatory comment at the end of the same line. And this has broken the value of the environment value leading to a very undescriptive error: `aiohttp.client_exceptions.ClientConnectorDNSError: Cannot connect to host host.docker.internal :80 ssl:default [Name does not resolve]`

This was coming from here:

https://github.com/ruecat/ollama-telegram/blob/4884bbd1e23902152c3468c9fbc717af56cbd9d2/bot/func/interactions.py#L94

However, the code seemed in this place seemed correct. Have you noticed in the error above that it tries to access port `80` instead of Ollama's default?

This is because Docker `.env` files do not support inline comments, and thus the entire line—including the comment—was interpreted as the variable’s value. This caused the `OLLAMA_BASE_URL` to be incorrect, leading to a confusing DNS resolution error when the container tried to connect to the Ollama server. In fact, the value was `host.docker.internal # to run ollama locally` (with all the comment remainder).

# Proposed Change

To avoid this issue, I propose moving all explanatory comments **above** each example line, instead of placing them inline. This way, the `.env` file remains valid, variable values are clean, and users can clearly understand the options without risking misconfiguration.